### PR TITLE
Add bmsDatagen library and documentation

### DIFF
--- a/bmsDatagen/src/bmsDatagen.c
+++ b/bmsDatagen/src/bmsDatagen.c
@@ -1,0 +1,25 @@
+#include "bmsDatagen.h"
+#include <zephyr.h>
+#include <device.h>
+#include <can/can_loopback.h>
+
+void periodic_message_bms(const struct device *dev)
+{
+    struct zcan_frame msg = {
+        .id_type = CAN_STANDARD_IDENTIFIER,
+        .rtr = CAN_DATAFRAME,
+        .id = 0x123,
+        .dlc = 8,
+        .data = {1,2,3,4,5,6,7,8}
+    };
+
+    struct k_timer t;
+    k_timer_init(&t, NULL, NULL);
+    
+    while(1){
+        
+        can_send(dev, &msg, K_MSEC(1), NULL, NULL);
+        k_timer_start(&t, K_MSEC(8), K_NO_WAIT);
+        k_timer_status_sync(&t);
+    }
+}

--- a/bmsDatagen/src/bmsDatagen.h
+++ b/bmsDatagen/src/bmsDatagen.h
@@ -1,0 +1,3 @@
+#include <device.h>
+
+void periodic_message_bms(const struct device *dev);

--- a/bmsDatagen_doc.md
+++ b/bmsDatagen_doc.md
@@ -1,0 +1,17 @@
+# BMS Communication over CAN
+
+We have designed some test code for an embedded system to connect into the CAN bus and act like the BMS used by the team. The BMS by Orion transmits data on an interval of 8ms. We designed our code to send 8 bytes of data that can be changed either dynamically or send static data to be interpreted and stored as battery info on the data log. This can be used to test the ability of the data logger in obtaining and storing data from the BMS.
+
+## Intended organization of bytes
+
+Bytes 0-3: DTC codes
+Byte 4: Battery percentage (in 0.5% increments)
+Byte 5: ID of cell with highest voltage
+Byte 6: ID of cell with lowest voltage
+Byte 7: Adaptive state of charge (compared to programmed values)
+
+## Future use
+
+This library can be changed in the future to use real DTC codes from the BMS documentation to update the data in the CAN frame using static definitions. At the current time, the data is static and does not reflect an updating condition inside a battery unit. It is useful only to assess the ability of the data logger to take BMS data from the CAN.
+
+This library should be used within a thread on the system you are using to communicate on CAN, it is just a sender designed to represent the BMS sending information periodically. We recommend just testing it in loopback mode. That way this library can be used in conjunction with other libraries for testing.


### PR DESCRIPTION
This library is designed to act like the BMS on a CAN bus and provide capability to test data logging from the BMS. Documentation has been included to instruct on how we originally intended its use and provided some suggestions for future use